### PR TITLE
Fix 'Documentation' link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/crates/l/cgmath.svg)](https://github.com/bjz/cgmath/blob/master/LICENSE)
 [![Downloads](https://img.shields.io/crates/d/cgmath.svg)](https://crates.io/crates/cgmath)
 
-[Documentation](http://bjz.github.io/cgmath)
+[Documentation](http://brendanzab.github.io/cgmath/cgmath/index.html)
 
 A linear algebra and mathematics library for computer graphics.
 


### PR DESCRIPTION
I left the '/index.html' but I suppose it'd be better without...