### PR TITLE
Removes #[repr(packed)] from all structs where it was specified.

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -30,8 +30,8 @@ use num::BaseFloat;
 
 /// An angle, in radians.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -39,8 +39,8 @@ pub struct Rad<S>(pub S);
 
 /// An angle, in degrees.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -25,7 +25,7 @@ use num::BaseFloat;
 
 /// A set of [Euler angles] representing a rotation in three-dimensional space.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
+/// This type is marked as `#[repr(C)]`.
 ///
 /// The axis rotation sequence is XYZ. That is, the rotation is first around
 /// the X axis, then the Y axis, and lastly the Z axis (using intrinsic
@@ -72,7 +72,7 @@ use num::BaseFloat;
 /// [Euler angles]: https://en.wikipedia.org/wiki/Euler_angles
 /// [gimbal lock]: https://en.wikipedia.org/wiki/Gimbal_lock#Gimbal_lock_in_applied_mathematics
 /// [convert]: #defining-rotations-using-euler-angles
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -33,8 +33,8 @@ use vector::{Vector2, Vector3, Vector4};
 
 /// A 2 x 2, column major matrix
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -47,8 +47,8 @@ pub struct Matrix2<S> {
 
 /// A 3 x 3, column major matrix
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -63,8 +63,8 @@ pub struct Matrix3<S> {
 
 /// A 4 x 4, column major matrix
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]

--- a/src/point.rs
+++ b/src/point.rs
@@ -29,8 +29,8 @@ use vector::{Vector1, Vector2, Vector3, Vector4};
 
 /// A point in 1-dimensional space.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -40,8 +40,8 @@ pub struct Point1<S> {
 
 /// A point in 2-dimensional space.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -52,8 +52,8 @@ pub struct Point2<S> {
 
 /// A point in 3-dimensional space.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -34,8 +34,8 @@ use vector::Vector3;
 /// A [quaternion](https://en.wikipedia.org/wiki/Quaternion) in scalar/vector
 /// form.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -27,8 +27,8 @@ use num::{BaseNum, BaseFloat, PartialOrd};
 
 /// A 1-dimensional vector.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -39,8 +39,8 @@ pub struct Vector1<S> {
 
 /// A 2-dimensional vector.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -53,8 +53,8 @@ pub struct Vector2<S> {
 
 /// A 3-dimensional vector.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
@@ -69,8 +69,8 @@ pub struct Vector3<S> {
 
 /// A 4-dimensional vector.
 ///
-/// This type is marked as `#[repr(C, packed)]`.
-#[repr(C, packed)]
+/// This type is marked as `#[repr(C)]`.
+#[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]


### PR DESCRIPTION
This is intended as a partial fix for #375. It doesn't also remove #[repr(C)],
since it's a bit unclear whether that's necessary.