### PR TITLE
Add flip_y_up_to_z_up method to Matrix4

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -299,6 +299,18 @@ impl<S: BaseFloat> Matrix4<S> {
                      S::zero(),
                      S::one())
     }
+    
+    /// Create a matrix which flips the y and z coordnates.
+    ///
+    /// This is used to transform from a y-up coordinate system to
+    /// a z-up coordinate systems.
+    #[inline]
+    pub fn flip_y_up_to_z_up() -> Matrix4<S> {
+        Matrix4::new(S::one(), S::zero(), S::zero(), S::zero(),
+                     S::zero(), S::zero(), S::one(), S::zero(),
+                     S::zero(), -S::one(), S::zero(), S::zero(),
+                     S::zero(), S::zero(), S::zero(), S::one())
+    }
 }
 
 impl<S: BaseFloat> Zero for Matrix2<S> {


### PR DESCRIPTION
This is for converting between models which often come in a y-up coordinate system (maya) and game which often use a z-up system.

Math from http://stackoverflow.com/questions/22571364/threejs-matrix-from-z-up-coordinate-system-to-y-up-coordinate-system