### PR TITLE
Use serde_derive instead of serde_macros.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "cgmath"
 [features]
 unstable = []
 default = ["rustc-serialize"]
-eders = ["serde", "serde_macros"]
+eders = ["serde", "serde_derive"]
 
 [dependencies]
 approx = "0.1"
@@ -37,7 +37,7 @@ num-traits = "0.1"
 rand = "0.3"
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "0.8", optional = true }
-serde_macros = { version = "0.8", optional = true }
+serde_derive = { version = "0.8", optional = true }
 
 [dev-dependencies]
 glium = "0.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,7 @@
 //! use cgmath::prelude::*;
 //! ```
 
-#![cfg_attr(feature = "eders", feature(plugin, custom_derive))]
-#![cfg_attr(feature = "eders", plugin(serde_macros))]
+#![cfg_attr(feature = "eders", feature(proc_macro))]
 
 #[macro_use]
 extern crate approx;
@@ -61,6 +60,9 @@ extern crate rand;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
+#[cfg(feature = "eders")]
+#[macro_use]
+extern crate serde_derive;
 #[cfg(feature = "eders")]
 extern crate serde;
 


### PR DESCRIPTION
It looks like serde_macros was removed in serde 0.8.11 - https://github.com/serde-rs/serde/commit/1b6fd5a362ae1925153213ab329678a4ce2e2ce4.