### PR TITLE
Bump to serde 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ rust:
   - stable
 
 script:
-  - cargo build && cargo test
+  - cargo build && cargo test && cargo test --features "eders"
   - if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then cargo bench; fi
   - if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then cargo build --features "use_simd" && cargo test --features "use_simd" && cargo bench --features "use_simd"; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ approx = "0.1"
 num-traits = "0.1"
 rand = "0.3"
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "0.8", optional = true }
-serde_derive = { version = "0.8", optional = true }
+serde = { version = "0.9", optional = true }
+serde_derive = { version = "0.9", optional = true }
 simd = { version = "0.2", optional = true }
 
 [dev-dependencies]
 glium = "0.15"
-serde_json = "0.8"
+serde_json = "0.9"


### PR DESCRIPTION
Use Serde 0.9 that no longer requires the usage of Nightly. Fixes #398.

Also adds a test run for `--features eders` to Travis config.