### PR TITLE
Drop rustc-serialize support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ name = "cgmath"
 
 [features]
 unstable = []
-default = ["rustc-serialize"]
 eders = ["serde", "serde_derive"]
 use_simd = ["simd"]
 
@@ -36,7 +35,6 @@ use_simd = ["simd"]
 approx = "0.1"
 num-traits = "0.1"
 rand = "0.3"
-rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "0.9", optional = true }
 serde_derive = { version = "0.9", optional = true }
 simd = { version = "0.2", optional = true }

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -33,7 +33,6 @@ use num::BaseFloat;
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Rad<S>(pub S);
 
@@ -42,7 +41,6 @@ pub struct Rad<S>(pub S);
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Deg<S>(pub S);
 

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -75,7 +75,6 @@ use num::BaseFloat;
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Euler<A: Angle> {
     /// The angle to apply around the _x_ axis. Also known at the _pitch_.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,6 @@ extern crate approx;
 pub extern crate num_traits;
 extern crate rand;
 
-#[cfg(feature = "rustc-serialize")]
-extern crate rustc_serialize;
-
 #[cfg(feature = "eders")]
 #[macro_use]
 extern crate serde_derive;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -36,7 +36,6 @@ use vector::{Vector2, Vector3, Vector4};
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Matrix2<S> {
     /// The first column of the matrix.
@@ -50,7 +49,6 @@ pub struct Matrix2<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Matrix3<S> {
     /// The first column of the matrix.
@@ -66,7 +64,6 @@ pub struct Matrix3<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Matrix4<S> {
     /// The first column of the matrix.

--- a/src/point.rs
+++ b/src/point.rs
@@ -33,7 +33,6 @@ use vector::{Vector1, Vector2, Vector3, Vector4};
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Point1<S> {
     pub x: S,
@@ -44,7 +43,6 @@ pub struct Point1<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Point2<S> {
     pub x: S,
@@ -56,7 +54,6 @@ pub struct Point2<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Point3<S> {
     pub x: S,

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -135,7 +135,6 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
 
 /// A perspective projection with arbitrary left/right/bottom/top distances
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Perspective<S> {
     pub left:   S,
@@ -183,7 +182,6 @@ impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
 
 /// An orthographic projection with arbitrary left/right/bottom/top distances
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Ortho<S> {
     pub left:   S,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -39,7 +39,6 @@ use simd::f32x4 as Simdf32x4;
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Quaternion<S> {
     /// The scalar part of the quaternion.

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -140,7 +140,6 @@ pub trait Rotation3<S: BaseFloat>: Rotation<Point3<S>>
 /// // assert_ulps_eq!(&unit_y3, &unit_y2); // TODO: Figure out how to use this
 /// ```
 #[derive(PartialEq, Copy, Clone)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Basis2<S> {
     mat: Matrix2<S>
@@ -234,7 +233,6 @@ impl<S: fmt::Debug> fmt::Debug for Basis2<S> {
 /// `math::Matrix3`. To ensure orthogonality is maintained, the operations have
 /// been restricted to a subset of those implemented on `Matrix3`.
 #[derive(PartialEq, Copy, Clone)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Basis3<S> {
     mat: Matrix3<S>

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -57,7 +57,6 @@ pub trait Transform<P: EuclideanSpace>: Sized {
 /// A generic transformation consisting of a rotation,
 /// displacement vector and scale amount.
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 pub struct Decomposed<V: VectorSpace, R> {
     pub scale: V::Scalar,
     pub rot: R,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -37,7 +37,6 @@ use simd::u32x4 as Simdu32x4;
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector1<S> {
     /// The x component of the vector.
@@ -49,7 +48,6 @@ pub struct Vector1<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector2<S> {
     /// The x component of the vector.
@@ -63,7 +61,6 @@ pub struct Vector2<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector3<S> {
     /// The x component of the vector.
@@ -79,7 +76,6 @@ pub struct Vector3<S> {
 /// This type is marked as `#[repr(C)]`.
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct Vector4<S> {
     /// The x component of the vector.


### PR DESCRIPTION
According to [Rust release milestone predictions](https://internals.rust-lang.org/t/rust-release-milestone-predictions/4591?u=dtolnay), rustc-serialize is scheduled to be deprecated in next month's beta release of Rust.

Closes #395