### PR TITLE
Sum and Product cleanups

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -17,6 +17,7 @@
 
 use std::fmt;
 use std::f64;
+use std::iter;
 use std::ops::*;
 
 use rand::{Rand, Rng};
@@ -69,6 +70,20 @@ macro_rules! impl_angle {
             #[inline]
             fn is_zero(&self) -> bool {
                 ulps_eq!(self, &Self::zero())
+            }
+        }
+
+        impl<S: BaseFloat> iter::Sum<$Angle<S>> for $Angle<S> {
+            #[inline]
+            fn sum<I: Iterator<Item=$Angle<S>>>(iter: I) -> $Angle<S> {
+                iter.fold($Angle::zero(), Add::add)
+            }
+        }
+
+        impl<'a, S: 'a + BaseFloat> iter::Sum<&'a $Angle<S>> for $Angle<S> {
+            #[inline]
+            fn sum<I: Iterator<Item=&'a $Angle<S>>>(iter: I) -> $Angle<S> {
+                iter.fold($Angle::zero(), Add::add)
             }
         }
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -657,7 +657,7 @@ impl<S: BaseFloat> SquareMatrix for Matrix4<S> {
                      self[3][3])
     }
 
-    // The new implementation results in negative optimization when used 
+    // The new implementation results in negative optimization when used
     // without SIMD. so we opt them in with configuration.
     // A better option would be using specialization. But currently somewhat
     // specialization is too buggy, and it won't apply here. I'm getting
@@ -968,31 +968,31 @@ macro_rules! impl_matrix {
             fn sub_assign(&mut self, other: $MatrixN<S>) { $(self.$field -= other.$field);+ }
         }
 
-        impl<S: BaseFloat> iter::Sum for $MatrixN<S> {
+        impl<S: BaseFloat> iter::Sum<$MatrixN<S>> for $MatrixN<S> {
             #[inline]
-            fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), Add::add)
+            fn sum<I: Iterator<Item=$MatrixN<S>>>(iter: I) -> $MatrixN<S> {
+                iter.fold($MatrixN::zero(), Add::add)
             }
         }
 
-        impl<'a, S: 'a + BaseFloat> iter::Sum<&'a Self> for $MatrixN<S> {
+        impl<'a, S: 'a + BaseFloat> iter::Sum<&'a $MatrixN<S>> for $MatrixN<S> {
             #[inline]
-            fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), Add::add)
+            fn sum<I: Iterator<Item=&'a $MatrixN<S>>>(iter: I) -> $MatrixN<S> {
+                iter.fold($MatrixN::zero(), Add::add)
             }
         }
 
         impl<S: BaseFloat> iter::Product for $MatrixN<S> {
             #[inline]
-            fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold(Self::identity(), Mul::mul)
+            fn product<I: Iterator<Item=$MatrixN<S>>>(iter: I) -> $MatrixN<S> {
+                iter.fold($MatrixN::identity(), Mul::mul)
             }
         }
 
-        impl<'a, S: 'a + BaseFloat> iter::Product<&'a Self> for $MatrixN<S> {
+        impl<'a, S: 'a + BaseFloat> iter::Product<&'a $MatrixN<S>> for $MatrixN<S> {
             #[inline]
-            fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold(Self::identity(), Mul::mul)
+            fn product<I: Iterator<Item=&'a $MatrixN<S>>>(iter: I) -> $MatrixN<S> {
+                iter.fold($MatrixN::identity(), Mul::mul)
             }
         }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -188,31 +188,31 @@ impl<S: BaseFloat> One for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> iter::Sum for Quaternion<S> {
+impl<S: BaseFloat> iter::Sum<Quaternion<S>> for Quaternion<S> {
     #[inline]
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-        iter.fold(Self::zero(), Add::add)
+    fn sum<I: Iterator<Item=Quaternion<S>>>(iter: I) -> Quaternion<S> {
+        iter.fold(Quaternion::<S>::zero(), Add::add)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Sum<&'a Self> for Quaternion<S> {
+impl<'a, S: 'a + BaseFloat> iter::Sum<&'a Quaternion<S>> for Quaternion<S> {
     #[inline]
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-        iter.fold(Self::zero(), Add::add)
+    fn sum<I: Iterator<Item=&'a Quaternion<S>>>(iter: I) -> Quaternion<S> {
+        iter.fold(Quaternion::<S>::zero(), Add::add)
     }
 }
 
-impl<S: BaseFloat> iter::Product for Quaternion<S> {
+impl<S: BaseFloat> iter::Product<Quaternion<S>> for Quaternion<S> {
     #[inline]
-    fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
-        iter.fold(Self::one(), Mul::mul)
+    fn product<I: Iterator<Item=Quaternion<S>>>(iter: I) -> Quaternion<S> {
+        iter.fold(Quaternion::<S>::one(), Mul::mul)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Product<&'a Self> for Quaternion<S> {
+impl<'a, S: 'a + BaseFloat> iter::Product<&'a Quaternion<S>> for Quaternion<S> {
     #[inline]
-    fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-        iter.fold(Self::one(), Mul::mul)
+    fn product<I: Iterator<Item=&'a Quaternion<S>>>(iter: I) -> Quaternion<S> {
+        iter.fold(Quaternion::<S>::one(), Mul::mul)
     }
 }
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -159,17 +159,17 @@ impl<S: BaseFloat> From<Basis2<S>> for Matrix2<S> {
     fn from(b: Basis2<S>) -> Matrix2<S> { b.mat }
 }
 
-impl<S: BaseFloat> iter::Product for Basis2<S> {
+impl<S: BaseFloat> iter::Product<Basis2<S>> for Basis2<S> {
     #[inline]
-    fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
-        iter.fold(Basis2 { mat: Matrix2::identity() }, Mul::mul)
+    fn product<I: Iterator<Item=Basis2<S>>>(iter: I) -> Basis2<S> {
+        iter.fold(Basis2::one(), Mul::mul)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Product<&'a Self> for Basis2<S> {
+impl<'a, S: 'a + BaseFloat> iter::Product<&'a Basis2<S>> for Basis2<S> {
     #[inline]
-    fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-        iter.fold(Basis2 { mat: Matrix2::identity() }, Mul::mul)
+    fn product<I: Iterator<Item=&'a Basis2<S>>>(iter: I) -> Basis2<S> {
+        iter.fold(Basis2::one(), Mul::mul)
     }
 }
 
@@ -279,17 +279,17 @@ impl<S: BaseFloat> From<Basis3<S>> for Quaternion<S> {
     fn from(b: Basis3<S>) -> Quaternion<S> { b.mat.into() }
 }
 
-impl<S: BaseFloat> iter::Product for Basis3<S> {
+impl<S: BaseFloat> iter::Product<Basis3<S>> for Basis3<S> {
     #[inline]
-    fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
-        iter.fold(Basis3 { mat: Matrix3::identity() }, Mul::mul)
+    fn product<I: Iterator<Item=Basis3<S>>>(iter: I) -> Basis3<S> {
+        iter.fold(Basis3::one(), Mul::mul)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Product<&'a Self> for Basis3<S> {
+impl<'a, S: 'a + BaseFloat> iter::Product<&'a Basis3<S>> for Basis3<S> {
     #[inline]
-    fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-        iter.fold(Basis3 { mat: Matrix3::identity() }, Mul::mul)
+    fn product<I: Iterator<Item=&'a Basis3<S>>>(iter: I) -> Basis3<S> {
+        iter.fold(Basis3::one(), Mul::mul)
     }
 }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -551,6 +551,8 @@ pub trait Angle where
     Self: Mul<<Self as Angle>::Unitless, Output = Self>,
     Self: Div<Self, Output = <Self as Angle>::Unitless>,
     Self: Div<<Self as Angle>::Unitless, Output = Self>,
+
+    Self: iter::Sum,
 {
     type Unitless: BaseFloat;
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -154,10 +154,10 @@ pub trait ElementWise<Rhs = Self> {
 /// ```
 pub trait VectorSpace: Copy + Clone where
     Self: Zero,
-    Self: iter::Sum<Self>,
 
     Self: Add<Self, Output = Self>,
     Self: Sub<Self, Output = Self>,
+    Self: iter::Sum<Self>,
 
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Mul<<Self as VectorSpace>::Scalar, Output = Self>,
@@ -457,7 +457,7 @@ pub trait SquareMatrix where
     Self::Scalar: BaseFloat,
 
     Self: One,
-    Self: iter::Product,
+    Self: iter::Product<Self>,
 
     Self: Matrix<
         // FIXME: Can be cleaned up once equality constraints in where clauses are implemented

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -164,17 +164,17 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<S: BaseNum> iter::Sum for $VectorN<S> {
+        impl<S: BaseNum> iter::Sum<$VectorN<S>> for $VectorN<S> {
             #[inline]
-            fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), Add::add)
+            fn sum<I: Iterator<Item=$VectorN<S>>>(iter: I) -> $VectorN<S> {
+                iter.fold($VectorN::zero(), Add::add)
             }
         }
 
-        impl<'a, S: 'a + BaseNum> iter::Sum<&'a Self> for $VectorN<S> {
+        impl<'a, S: 'a + BaseNum> iter::Sum<&'a $VectorN<S>> for $VectorN<S> {
             #[inline]
-            fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), Add::add)
+            fn sum<I: Iterator<Item=&'a $VectorN<S>>>(iter: I) -> $VectorN<S> {
+                iter.fold($VectorN::zero(), Add::add)
             }
         }
 

--- a/tests/angle.rs
+++ b/tests/angle.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 use cgmath::{Rad, Deg};
 
 #[test]
-fn conv() {
+fn test_conv() {
     let angle: Rad<_> = Deg(-5.0f64).into();
     let angle: Deg<_> = angle.into();
     assert_ulps_eq!(&angle, &Deg(-5.0f64));
@@ -36,4 +36,24 @@ fn conv() {
     let angle: Deg<_> = Rad(30.0f64).into();
     let angle: Rad<_> = angle.into();
     assert_ulps_eq!(&angle, &Rad(30.0f64));
+}
+
+mod rad {
+    use cgmath::Rad;
+
+    #[test]
+    fn test_iter_sum() {
+        assert_eq!(Rad(2.0) + Rad(3.0) + Rad(4.0), [Rad(2.0), Rad(3.0), Rad(4.0)].iter().sum());
+        assert_eq!(Rad(2.0) + Rad(3.0) + Rad(4.0), [Rad(2.0), Rad(3.0), Rad(4.0)].iter().cloned().sum());
+    }
+}
+
+mod deg {
+    use cgmath::Deg;
+
+    #[test]
+    fn test_iter_sum() {
+        assert_eq!(Deg(2.0) + Deg(3.0) + Deg(4.0), [Deg(2.0), Deg(3.0), Deg(4.0)].iter().sum());
+        assert_eq!(Deg(2.0) + Deg(3.0) + Deg(4.0), [Deg(2.0), Deg(3.0), Deg(4.0)].iter().cloned().sum());
+    }
 }

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -15,7 +15,6 @@
 
 #[macro_use]
 extern crate approx;
-#[macro_use]
 extern crate cgmath;
 
 pub mod matrix2 {
@@ -98,14 +97,14 @@ pub mod matrix2 {
 
     #[test]
     fn test_sum_matrix() {
-        let res: Matrix2<f64> = [A, B, C].iter().sum();
-        assert_eq!(res, A + B + C);
+        assert_eq!(A + B + C, [A, B, C].iter().sum());
+        assert_eq!(A + B + C, [A, B, C].iter().cloned().sum());
     }
 
     #[test]
     fn test_product_matrix() {
-        let res: Matrix2<f64> = [A, B, C].iter().product();
-        assert_eq!(res, A * B * C);
+        assert_eq!(A * B * C, [A, B, C].iter().product());
+        assert_eq!(A * B * C, [A, B, C].iter().cloned().product());
     }
 
     #[test]
@@ -272,14 +271,14 @@ pub mod matrix3 {
 
     #[test]
     fn test_sum_matrix() {
-        let res: Matrix3<f64> = [A, B, C, D].iter().sum();
-        assert_eq!(res, A + B + C + D);
+        assert_eq!(A + B + C + D, [A, B, C, D].iter().sum());
+        assert_eq!(A + B + C + D, [A, B, C, D].iter().cloned().sum());
     }
 
     #[test]
     fn test_product_matrix() {
-        let res: Matrix3<f64> = [A, B, C, D].iter().product();
-        assert_eq!(res, A * B * C * D);
+        assert_eq!(A * B * C * D, [A, B, C, D].iter().product());
+        assert_eq!(A * B * C * D, [A, B, C, D].iter().cloned().product());
     }
 
     #[test]
@@ -641,14 +640,14 @@ pub mod matrix4 {
 
     #[test]
     fn test_sum_matrix() {
-        let res: Matrix4<f64> = [A, B, C, D].iter().sum();
-        assert_eq!(res, A + B + C + D);
+        assert_eq!(A + B + C + D, [A, B, C, D].iter().sum());
+        assert_eq!(A + B + C + D, [A, B, C, D].iter().cloned().sum());
     }
 
     #[test]
     fn test_product_matrix() {
-        let res: Matrix4<f64> = [A, B, C, D].iter().product();
-        assert_eq!(res, A * B * C * D);
+        assert_eq!(A * B * C * D, [A, B, C, D].iter().product());
+        assert_eq!(A * B * C * D, [A, B, C, D].iter().cloned().product());
     }
 
     #[test]

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -15,7 +15,6 @@
 
 #[macro_use]
 extern crate approx;
-#[macro_use]
 extern crate cgmath;
 
 macro_rules! impl_test_mul {
@@ -54,13 +53,21 @@ mod operators {
     }
 
     #[test]
+    fn test_iter_sum() {
+        let q1 = Quaternion::from(Euler { x: Rad(2f32), y: Rad(1f32), z: Rad(1f32) });
+        let q2 = Quaternion::from(Euler { x: Rad(1f32), y: Rad(2f32), z: Rad(1f32) });
+        let q3 = Quaternion::from(Euler { x: Rad(1f32), y: Rad(1f32), z: Rad(2f32) });
+
+        assert_eq!(q1 + q2 + q3, [q1, q2, q3].iter().sum());
+    }
+
+    #[test]
     fn test_iter_product() {
         let q1 = Quaternion::from(Euler { x: Rad(2f32), y: Rad(1f32), z: Rad(1f32) });
         let q2 = Quaternion::from(Euler { x: Rad(1f32), y: Rad(2f32), z: Rad(1f32) });
         let q3 = Quaternion::from(Euler { x: Rad(1f32), y: Rad(1f32), z: Rad(2f32) });
 
-        let res: Quaternion<f32> = [q1, q2, q3].iter().product();
-        assert_eq!(res, q1 * q2 * q3);
+        assert_eq!(q1 * q2 * q3, [q1, q2, q3].iter().product());
     }
 }
 

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -59,6 +59,7 @@ mod operators {
         let q3 = Quaternion::from(Euler { x: Rad(1f32), y: Rad(1f32), z: Rad(2f32) });
 
         assert_eq!(q1 + q2 + q3, [q1, q2, q3].iter().sum());
+        assert_eq!(q1 + q2 + q3, [q1, q2, q3].iter().cloned().sum());
     }
 
     #[test]
@@ -68,6 +69,7 @@ mod operators {
         let q3 = Quaternion::from(Euler { x: Rad(1f32), y: Rad(1f32), z: Rad(2f32) });
 
         assert_eq!(q1 * q2 * q3, [q1, q2, q3].iter().product());
+        assert_eq!(q1 * q2 * q3, [q1, q2, q3].iter().cloned().product());
     }
 }
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -15,7 +15,6 @@
 
 #[macro_use]
 extern crate approx;
-#[macro_use]
 extern crate cgmath;
 
 use cgmath::*;
@@ -90,9 +89,8 @@ macro_rules! impl_test_rem {
 
 macro_rules! impl_test_iter_sum {
     ($VectorN:ident { $($field:ident),+ }, $ty:ty, $s:expr, $v:expr) => (
-        let res: $VectorN<$ty> = iter::repeat($v).take($s as usize).sum();
-        assert_eq!(res,
-                   $VectorN::new($($v.$field * $s),+));
+        assert_eq!($VectorN::new($($v.$field * $s),+),
+                   iter::repeat($v).take($s as usize).sum());
     )
 }
 

--- a/tests/vector4f32.rs
+++ b/tests/vector4f32.rs
@@ -15,7 +15,6 @@
 
 #[macro_use]
 extern crate approx;
-#[macro_use]
 extern crate cgmath;
 
 use cgmath::*;
@@ -168,7 +167,6 @@ mod test_magnitude {
             assert_relative_eq!(a.sqrt_element_wide().recip_element_wide(), Vector4::new(1f32, 1f32/2f32, 1f32/3f32, 1f32/4f32), max_relative = 0.005f32);
             assert_relative_eq!(a.rsqrt_element_wide(), Vector4::new(1f32, 1f32/2f32, 1f32/3f32, 1f32/4f32), max_relative= 0.005f32);
         }
-        
     }
 }
 


### PR DESCRIPTION
This continues on from #406

I cleaned up the impls to be consistent with the other code in cgmath, and implemented `Sum` for `Angle`s. I also reordered the assertions so that type inference worked, and ensured that the tests covered both taking the iterator items by value _and_ by ref.