### PR TITLE
Workaround rust-lang/rust#41478.

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1133,7 +1133,7 @@ index_operators!(Matrix4<S>, 4, Vector4<S>, usize);
 // index_operators!(Matrix3<S>, 3, [Vector3<S>], RangeFull);
 // index_operators!(Matrix4<S>, 4, [Vector4<S>], RangeFull);
 
-impl<A> From<Euler<A>> for Matrix3<<A as Angle>::Unitless> where
+impl<A> From<Euler<A>> for Matrix3<A::Unitless> where
     A: Angle + Into<Rad<<A as Angle>::Unitless>>,
 {
     fn from(src: Euler<A>) -> Matrix3<A::Unitless> {
@@ -1148,7 +1148,7 @@ impl<A> From<Euler<A>> for Matrix3<<A as Angle>::Unitless> where
     }
 }
 
-impl<A> From<Euler<A>> for Matrix4<<A as Angle>::Unitless> where
+impl<A> From<Euler<A>> for Matrix4<A::Unitless> where
     A: Angle + Into<Rad<<A as Angle>::Unitless>>,
 {
     fn from(src: Euler<A>) -> Matrix4<A::Unitless> {

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -256,7 +256,7 @@ impl InnerSpace for Quaternion<f32> {
     }
 }
 
-impl<A> From<Euler<A>> for Quaternion<<A as Angle>::Unitless> where
+impl<A> From<Euler<A>> for Quaternion<A::Unitless> where
     A: Angle + Into<Rad<<A as Angle>::Unitless>>,
 {
     fn from(src: Euler<A>) -> Quaternion<A::Unitless> {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -370,7 +370,7 @@ impl<S: BaseFloat> Rotation3<S> for Basis3<S> {
     }
 }
 
-impl<A: Angle> From<Euler<A>> for Basis3<<A as Angle>::Unitless> where
+impl<A: Angle> From<Euler<A>> for Basis3<A::Unitless> where
     A: Into<Rad<<A as Angle>::Unitless>>,
 {
     /// Create a three-dimensional rotation matrix from a set of euler angles.


### PR DESCRIPTION
Replace all `impl .. for Struct<<A as Angle>::Unitless>` by `Struct<A::Unitless>`. 

This allows `-Zsave-analysis` to work, and I think this is more readable too.