### PR TITLE
Remove PartialOrd

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -15,105 +15,17 @@
 
 use approx::ApproxEq;
 
-use std::cmp;
 use std::fmt;
 use std::ops::*;
 
 use num_traits::{Float, Num, NumCast};
 
-/// A trait providing a [partial ordering](http://mathworld.wolfram.com/PartialOrder.html).
-pub trait PartialOrd {
-    fn partial_min(self, other: Self) -> Self;
-    fn partial_max(self, other: Self) -> Self;
-}
-
-macro_rules! partial_ord_int (
-    ($T:ident) => (
-        impl PartialOrd for $T {
-            fn partial_min(self, other: $T) -> $T { cmp::min(self, other) }
-            fn partial_max(self, other: $T) -> $T { cmp::max(self, other) }
-        }
-    )
-);
-
-partial_ord_int!(isize);
-partial_ord_int!(i8);
-partial_ord_int!(i16);
-partial_ord_int!(i32);
-partial_ord_int!(i64);
-partial_ord_int!(usize);
-partial_ord_int!(u8);
-partial_ord_int!(u16);
-partial_ord_int!(u32);
-partial_ord_int!(u64);
-
-macro_rules! partial_ord_float (
-    ($T:ident) => (
-        impl PartialOrd for $T {
-            fn partial_min(self, other: $T) -> $T { self.min(other) }
-            fn partial_max(self, other: $T) -> $T { self.max(other) }
-        }
-    )
-);
-
-partial_ord_float!(f32);
-partial_ord_float!(f64);
-
-
 /// Base numeric types with partial ordering
-pub trait BaseNum where
-    Self: Copy + Clone + fmt::Debug,
-    Self: Num + NumCast,
-    Self: PartialOrd + cmp::PartialOrd,
-    Self: AddAssign + SubAssign,
-    Self: MulAssign + DivAssign + RemAssign,
-{}
+pub trait BaseNum: Copy + Clone + fmt::Debug + Num + NumCast + PartialOrd + AddAssign + SubAssign + MulAssign + DivAssign + RemAssign {}
 
-
-macro_rules! impl_basenum_int (
-    ($T: ident) => (
-        impl BaseNum for $T {}
-    )
-);
-
-impl_basenum_int!(i8);
-impl_basenum_int!(i16);
-impl_basenum_int!(i32);
-impl_basenum_int!(i64);
-impl_basenum_int!(u8);
-impl_basenum_int!(u16);
-impl_basenum_int!(u32);
-impl_basenum_int!(u64);
-impl_basenum_int!(isize);
-impl_basenum_int!(usize);
-
-
-macro_rules! impl_basenum_float (
-    ($T: ident) => (
-        impl BaseNum for $T {}
-    )
-);
-
-impl_basenum_float!(f32);
-impl_basenum_float!(f64);
-
-
-/// Base integer types
-pub trait BaseInt : BaseNum {}
-
-impl BaseInt for i8 {}
-impl BaseInt for i16 {}
-impl BaseInt for i32 {}
-impl BaseInt for i64 {}
-impl BaseInt for isize {}
-impl BaseInt for u8 {}
-impl BaseInt for u16 {}
-impl BaseInt for u32 {}
-impl BaseInt for u64 {}
-impl BaseInt for usize {}
+impl<T> BaseNum for T where T: Copy + Clone + fmt::Debug + Num + NumCast + PartialOrd + AddAssign + SubAssign + MulAssign + DivAssign + RemAssign {}
 
 /// Base floating point types
-pub trait BaseFloat : BaseNum + Float + ApproxEq<Epsilon = Self> {}
+pub trait BaseFloat: BaseNum + Float + ApproxEq<Epsilon = Self> {}
 
-impl BaseFloat for f32 {}
-impl BaseFloat for f64 {}
+impl<T> BaseFloat for T where T: BaseNum + Float + ApproxEq<Epsilon = Self> {}

--- a/src/point.rs
+++ b/src/point.rs
@@ -114,16 +114,6 @@ macro_rules! impl_point {
             fn product(self) -> S where S: Mul<Output = S> {
                 fold_array!(mul, { $(self.$field),+ })
             }
-
-            #[inline]
-            fn min(self) -> S where S: PartialOrd {
-                fold_array!(partial_min, { $(self.$field),+ })
-            }
-
-            #[inline]
-            fn max(self) -> S where S: PartialOrd {
-                fold_array!(partial_max, { $(self.$field),+ })
-            }
         }
 
         impl<S: NumCast + Copy> $PointN<S> {

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -23,7 +23,7 @@ use std::ops::*;
 use approx::ApproxEq;
 
 use angle::Rad;
-use num::{BaseNum, BaseFloat, PartialOrd};
+use num::{BaseNum, BaseFloat};
 
 pub use num_traits::{One, Zero};
 
@@ -72,12 +72,6 @@ pub trait Array where
 
     /// The product of the elements of the array.
     fn product(self) -> Self::Element where Self::Element: Mul<Output = <Self as Array>::Element>;
-
-    /// The minimum element of the array.
-    fn min(self) -> Self::Element where Self::Element: PartialOrd;
-
-    /// The maximum element of the array.
-    fn max(self) -> Self::Element where Self::Element: PartialOrd;
 }
 
 /// Element-wise arithmetic operations. These are supplied for pragmatic

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -24,7 +24,7 @@ use structure::*;
 
 use angle::Rad;
 use approx::ApproxEq;
-use num::{BaseNum, BaseFloat, PartialOrd};
+use num::{BaseNum, BaseFloat};
 
 #[cfg(feature = "use_simd")]
 use simd::f32x4 as Simdf32x4;
@@ -139,16 +139,6 @@ macro_rules! impl_vector {
             #[inline]
             fn product(self) -> S where S: Mul<Output = S> {
                 fold_array!(mul, { $(self.$field),+ })
-            }
-
-            #[inline]
-            fn min(self) -> S where S: PartialOrd {
-                fold_array!(partial_min, { $(self.$field),+ })
-            }
-
-            #[inline]
-            fn max(self) -> S where S: PartialOrd {
-                fold_array!(partial_max, { $(self.$field),+ })
             }
         }
 
@@ -361,16 +351,6 @@ macro_rules! impl_vector_default {
             #[inline]
             fn product(self) -> S where S: Mul<Output = S> {
                 fold_array!(mul, { $(self.$field),+ })
-            }
-
-            #[inline]
-            fn min(self) -> S where S: PartialOrd {
-                fold_array!(partial_min, { $(self.$field),+ })
-            }
-
-            #[inline]
-            fn max(self) -> S where S: PartialOrd {
-                fold_array!(partial_max, { $(self.$field),+ })
             }
         }
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -170,28 +170,6 @@ fn test_product() {
 }
 
 #[test]
-fn test_min() {
-    assert_eq!(Vector2::new(1isize, 2isize).min(), 1isize);
-    assert_eq!(Vector3::new(1isize, 2isize, 3isize).min(), 1isize);
-    assert_eq!(Vector4::new(1isize, 2isize, 3isize, 4isize).min(), 1isize);
-
-    assert_eq!(Vector2::new(3.0f64, 4.0f64).min(), 3.0f64);
-    assert_eq!(Vector3::new(4.0f64, 5.0f64, 6.0f64).min(), 4.0f64);
-    assert_eq!(Vector4::new(5.0f64, 6.0f64, 7.0f64, 8.0f64).min(), 5.0f64);
-}
-
-#[test]
-fn test_max() {
-    assert_eq!(Vector2::new(1isize, 2isize).max(), 2isize);
-    assert_eq!(Vector3::new(1isize, 2isize, 3isize).max(), 3isize);
-    assert_eq!(Vector4::new(1isize, 2isize, 3isize, 4isize).max(), 4isize);
-
-    assert_eq!(Vector2::new(3.0f64, 4.0f64).max(), 4.0f64);
-    assert_eq!(Vector3::new(4.0f64, 5.0f64, 6.0f64).max(), 6.0f64);
-    assert_eq!(Vector4::new(5.0f64, 6.0f64, 7.0f64, 8.0f64).max(), 8.0f64);
-}
-
-#[test]
 fn test_cross() {
     let a = Vector3::new(1isize, 2isize, 3isize);
     let b = Vector3::new(4isize, 5isize, 6isize);

--- a/tests/vector4f32.rs
+++ b/tests/vector4f32.rs
@@ -127,20 +127,6 @@ fn test_product() {
 }
 
 #[test]
-fn test_min() {
-    assert_eq!(Vector4::new(1f32, 2f32, 3f32, 4f32).min(), 1f32);
-
-    assert_eq!(Vector4::new(5.0f32, 6.0f32, 7.0f32, 8.0f32).min(), 5.0f32);
-}
-
-#[test]
-fn test_max() {
-    assert_eq!(Vector4::new(1f32, 2f32, 3f32, 4f32).max(), 4f32);
-
-    assert_eq!(Vector4::new(5.0f32, 6.0f32, 7.0f32, 8.0f32).max(), 8.0f32);
-}
-
-#[test]
 fn test_is_perpendicular() {
     assert!(Vector4::new(1.0f32, 0.0f32, 0.0f32, 0.0f32).is_perpendicular(Vector4::new(0.0f32, 0.0f32, 0.0f32, 1.0f32)));
 }


### PR DESCRIPTION
Closes #396

This removes `PartialOrd` and makes `BaseNum` and `BaseFloat` simple trait aliases. This should allow more types to be used as parameters in the cgmath data types at the expense of removing `Array::min` and `Array::max`.