### PR TITLE
Add cast method to Quaternion

### DIFF
--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -18,7 +18,7 @@ use std::mem;
 use std::ops::*;
 
 use rand::{Rand, Rng};
-use num_traits::cast;
+use num_traits::{NumCast, cast};
 
 use structure::*;
 
@@ -226,6 +226,13 @@ impl<S: BaseFloat> MetricSpace for Quaternion<S> {
     #[inline]
     fn distance2(self, other: Self) -> S {
         (other - self).magnitude2()
+    }
+}
+
+impl<S: NumCast + Copy> Quaternion<S> {
+    /// Component-wise casting to another type.
+    pub fn cast<T: BaseFloat>(&self) -> Quaternion<T> {
+        Quaternion::from_sv(NumCast::from(self.s).unwrap(), self.v.cast())
     }
 }
 

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -331,3 +331,13 @@ mod rotate_between_vectors {
         assert_ulps_eq!(Quaternion::between_vectors(a, b), expected);
     }
 }
+
+mod cast {
+    use cgmath::*;
+
+    #[test]
+    fn test_cast() {
+        assert_ulps_eq!(Quaternion::new(0.9f64, 1.5, 2.4, 7.6).cast(),
+                        Quaternion::new(0.9f32, 1.5, 2.4, 7.6));
+    }
+}


### PR DESCRIPTION
I'm not sure if the doc comment is correct (I just copied it from the vector method).