### PR TITLE
update glium to version 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ serde = { version = "1.0", features = ["serde_derive"], optional = true }
 simd = { version = "0.2", optional = true }
 
 [dev-dependencies]
-glium = "0.16"
+glium = "0.17"
 serde_json = "1.0"


### PR DESCRIPTION
old version of cocoa wasn't building on nightly (it's a dependency of glium->glutin->cocoa and glium->glutin->winit->cocoa on osx)
updating glium fixes it