### PR TITLE
condensed duplicate code for trait specialization using macros

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -18,14 +18,18 @@ use approx::ApproxEq;
 use std::fmt;
 use std::ops::*;
 
-use num_traits::{Float, Num, NumCast};
+use num_traits::{Float, Num, NumCast, Signed};
 
 /// Base numeric types with partial ordering
 pub trait BaseNum: Copy + Clone + fmt::Debug + Num + NumCast + PartialOrd + AddAssign + SubAssign + MulAssign + DivAssign + RemAssign {}
 
 impl<T> BaseNum for T where T: Copy + Clone + fmt::Debug + Num + NumCast + PartialOrd + AddAssign + SubAssign + MulAssign + DivAssign + RemAssign {}
 
-/// Base floating point types
-pub trait BaseFloat: BaseNum + Float + ApproxEq<Epsilon = Self> {}
+/// Base signed types
+pub trait BaseSigned: BaseNum + Signed {}
 
-impl<T> BaseFloat for T where T: BaseNum + Float + ApproxEq<Epsilon = Self> {}
+impl<T> BaseSigned for T where T: BaseNum + Signed {}
+/// Base floating point types
+pub trait BaseFloat: BaseSigned + Float + ApproxEq<Epsilon = Self> {}
+
+impl<T> BaseFloat for T where T: BaseSigned + Float + ApproxEq<Epsilon = Self> {}

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -239,20 +239,10 @@ impl<S: NumCast + Copy> Quaternion<S> {
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl<S: BaseFloat> InnerSpace for Quaternion<S> {
-    #[inline]
-    fn dot(self, other: Quaternion<S>) -> S {
-        self.s * other.s + self.v.dot(other.v)
-    }
-}
-
-#[cfg(feature = "simd")]
-impl<S: BaseFloat> InnerSpace for Quaternion<S> {
-    #[inline]
-    default fn dot(self, other: Quaternion<S>) -> S {
-        self.s * other.s + self.v.dot(other.v)
-    }
+    impl_fn!(fn dot(lhs, other: Quaternion<S>) -> S {
+        lhs.s * other.s + lhs.v.dot(other.v)
+    });
 }
 
 #[cfg(feature = "simd")]
@@ -287,15 +277,7 @@ impl<A> From<Euler<A>> for Quaternion<A::Unitless> where
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_operator!(<S: BaseFloat> Neg for Quaternion<S> {
-    fn neg(quat) -> Quaternion<S> {
-        Quaternion::from_sv(-quat.s, -quat.v)
-    }
-});
-
-#[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Neg for Quaternion<S> {
     fn neg(quat) -> Quaternion<S> {
         Quaternion::from_sv(-quat.s, -quat.v)
     }
@@ -310,15 +292,7 @@ impl_operator_simd!{
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_operator!(<S: BaseFloat> Mul<S> for Quaternion<S> {
-    fn mul(lhs, rhs) -> Quaternion<S> {
-        Quaternion::from_sv(lhs.s * rhs, lhs.v * rhs)
-    }
-});
-
-#[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Mul<S> for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s * rhs, lhs.v * rhs)
     }
@@ -333,13 +307,7 @@ impl_operator_simd!{@rs
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_assignment_operator!(<S: BaseFloat> MulAssign<S> for Quaternion<S> {
-    fn mul_assign(&mut self, scalar) { self.s *= scalar; self.v *= scalar; }
-});
-
-#[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> MulAssign<S> for Quaternion<S> {
     fn mul_assign(&mut self, scalar) { self.s *= scalar; self.v *= scalar; }
 });
 
@@ -352,19 +320,12 @@ impl MulAssign<f32> for Quaternion<f32> {
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_operator!(<S: BaseFloat> Div<S> for Quaternion<S> {
     fn div(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s / rhs, lhs.v / rhs)
     }
 });
 
-#[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Div<S> for Quaternion<S> {
-    fn div(lhs, rhs) -> Quaternion<S> {
-        Quaternion::from_sv(lhs.s / rhs, lhs.v / rhs)
-    }
-});
 
 #[cfg(feature = "simd")]
 impl_operator_simd!{@rs
@@ -375,13 +336,7 @@ impl_operator_simd!{@rs
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_assignment_operator!(<S: BaseFloat> DivAssign<S> for Quaternion<S> {
-    fn div_assign(&mut self, scalar) { self.s /= scalar; self.v /= scalar; }
-});
-
-#[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> DivAssign<S> for Quaternion<S> {
     fn div_assign(&mut self, scalar) { self.s /= scalar; self.v /= scalar; }
 });
 
@@ -413,15 +368,7 @@ impl_operator!(<S: BaseFloat> Mul<Vector3<S> > for Quaternion<S> {
     }}
 });
 
-#[cfg(not(feature = "simd"))]
 impl_operator!(<S: BaseFloat> Add<Quaternion<S> > for Quaternion<S> {
-    fn add(lhs, rhs) -> Quaternion<S> {
-        Quaternion::from_sv(lhs.s + rhs.s, lhs.v + rhs.v)
-    }
-});
-
-#[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Add<Quaternion<S> > for Quaternion<S> {
     fn add(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s + rhs.s, lhs.v + rhs.v)
     }
@@ -436,13 +383,7 @@ impl_operator_simd!{
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_assignment_operator!(<S: BaseFloat> AddAssign<Quaternion<S> > for Quaternion<S> {
-    fn add_assign(&mut self, other) { self.s += other.s; self.v += other.v; }
-});
-
-#[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> AddAssign<Quaternion<S> > for Quaternion<S> {
     fn add_assign(&mut self, other) { self.s += other.s; self.v += other.v; }
 });
 
@@ -456,15 +397,7 @@ impl AddAssign for Quaternion<f32> {
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_operator!(<S: BaseFloat> Sub<Quaternion<S> > for Quaternion<S> {
-    fn sub(lhs, rhs) -> Quaternion<S> {
-        Quaternion::from_sv(lhs.s - rhs.s, lhs.v - rhs.v)
-    }
-});
-
-#[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Sub<Quaternion<S> > for Quaternion<S> {
     fn sub(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s - rhs.s, lhs.v - rhs.v)
     }
@@ -479,13 +412,7 @@ impl_operator_simd!{
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_assignment_operator!(<S: BaseFloat> SubAssign<Quaternion<S> > for Quaternion<S> {
-    fn sub_assign(&mut self, other) { self.s -= other.s; self.v -= other.v; }
-});
-
-#[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> SubAssign<Quaternion<S> > for Quaternion<S> {
     fn sub_assign(&mut self, other) { self.s -= other.s; self.v -= other.v; }
 });
 
@@ -499,18 +426,7 @@ impl SubAssign for Quaternion<f32> {
     }
 }
 
-#[cfg(not(feature = "simd"))]
 impl_operator!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
-    fn mul(lhs, rhs) -> Quaternion<S> {
-        Quaternion::new(lhs.s * rhs.s - lhs.v.x * rhs.v.x - lhs.v.y * rhs.v.y - lhs.v.z * rhs.v.z,
-                        lhs.s * rhs.v.x + lhs.v.x * rhs.s + lhs.v.y * rhs.v.z - lhs.v.z * rhs.v.y,
-                        lhs.s * rhs.v.y + lhs.v.y * rhs.s + lhs.v.z * rhs.v.x - lhs.v.x * rhs.v.z,
-                        lhs.s * rhs.v.z + lhs.v.z * rhs.s + lhs.v.x * rhs.v.y - lhs.v.y * rhs.v.x)
-    }
-});
-
-#[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::new(lhs.s * rhs.s - lhs.v.x * rhs.v.x - lhs.v.y * rhs.v.y - lhs.v.z * rhs.v.z,
                         lhs.s * rhs.v.x + lhs.v.x * rhs.s + lhs.v.y * rhs.v.z - lhs.v.z * rhs.v.y,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -24,7 +24,7 @@ use structure::*;
 
 use angle::Rad;
 use approx::ApproxEq;
-use num::{BaseNum, BaseFloat};
+use num::{BaseNum, BaseFloat, BaseSigned};
 
 #[cfg(feature = "simd")]
 use simd::f32x4 as Simdf32x4;
@@ -180,12 +180,9 @@ macro_rules! impl_vector {
             type Scalar = S;
         }
 
-        impl<S: Neg<Output = S>> Neg for $VectorN<S> {
-            type Output = $VectorN<S>;
-
-            #[inline]
-            fn neg(self) -> $VectorN<S> { $VectorN::new($(-self.$field),+) }
-        }
+        impl_operator!(<S: BaseSigned> Neg for $VectorN<S> {
+            fn neg(x) -> $VectorN<S> { $VectorN::new($(-x.$field),+) }
+        });
 
         impl<S: BaseFloat> ApproxEq for $VectorN<S> {
             type Epsilon = S::Epsilon;
@@ -259,31 +256,32 @@ macro_rules! impl_vector {
         });
 
         impl<S: BaseNum> ElementWise for $VectorN<S> {
-            #[inline] fn add_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field + rhs.$field),+) }
-            #[inline] fn sub_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field - rhs.$field),+) }
-            #[inline] fn mul_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field * rhs.$field),+) }
-            #[inline] fn div_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field / rhs.$field),+) }
-            #[inline] fn rem_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field % rhs.$field),+) }
+            
+            impl_fn!(fn add_element_wise(lhs, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(lhs.$field + rhs.$field),+) });
+            impl_fn!(fn sub_element_wise(lhs, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(lhs.$field - rhs.$field),+) });
+            impl_fn!(fn mul_element_wise(lhs, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(lhs.$field * rhs.$field),+) });
+            impl_fn!(fn div_element_wise(lhs, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(lhs.$field / rhs.$field),+) });
+            impl_fn!(fn rem_element_wise(lhs, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(lhs.$field % rhs.$field),+) });
 
-            #[inline] fn add_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field += rhs.$field);+ }
-            #[inline] fn sub_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field -= rhs.$field);+ }
-            #[inline] fn mul_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field *= rhs.$field);+ }
-            #[inline] fn div_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field /= rhs.$field);+ }
-            #[inline] fn rem_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field %= rhs.$field);+ }
+            impl_fn!(fn add_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field += rhs.$field);+ });
+            impl_fn!(fn sub_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field -= rhs.$field);+ });
+            impl_fn!(fn mul_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field *= rhs.$field);+ });
+            impl_fn!(fn div_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field /= rhs.$field);+ });
+            impl_fn!(fn rem_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field %= rhs.$field);+ });
         }
 
         impl<S: BaseNum> ElementWise<S> for $VectorN<S> {
-            #[inline] fn add_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field + rhs),+) }
-            #[inline] fn sub_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field - rhs),+) }
-            #[inline] fn mul_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field * rhs),+) }
-            #[inline] fn div_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field / rhs),+) }
-            #[inline] fn rem_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field % rhs),+) }
+            impl_fn!(fn add_element_wise(lhs, rhs: S) -> $VectorN<S> { $VectorN::new($(lhs.$field + rhs),+) });
+            impl_fn!(fn sub_element_wise(lhs, rhs: S) -> $VectorN<S> { $VectorN::new($(lhs.$field - rhs),+) });
+            impl_fn!(fn mul_element_wise(lhs, rhs: S) -> $VectorN<S> { $VectorN::new($(lhs.$field * rhs),+) });
+            impl_fn!(fn div_element_wise(lhs, rhs: S) -> $VectorN<S> { $VectorN::new($(lhs.$field / rhs),+) });
+            impl_fn!(fn rem_element_wise(lhs, rhs: S) -> $VectorN<S> { $VectorN::new($(lhs.$field % rhs),+) });
 
-            #[inline] fn add_assign_element_wise(&mut self, rhs: S) { $(self.$field += rhs);+ }
-            #[inline] fn sub_assign_element_wise(&mut self, rhs: S) { $(self.$field -= rhs);+ }
-            #[inline] fn mul_assign_element_wise(&mut self, rhs: S) { $(self.$field *= rhs);+ }
-            #[inline] fn div_assign_element_wise(&mut self, rhs: S) { $(self.$field /= rhs);+ }
-            #[inline] fn rem_assign_element_wise(&mut self, rhs: S) { $(self.$field %= rhs);+ }
+            impl_fn!(fn add_assign_element_wise(&mut self, rhs: S) { $(self.$field += rhs);+ });
+            impl_fn!(fn sub_assign_element_wise(&mut self, rhs: S) { $(self.$field -= rhs);+ });
+            impl_fn!(fn mul_assign_element_wise(&mut self, rhs: S) { $(self.$field *= rhs);+ });
+            impl_fn!(fn div_assign_element_wise(&mut self, rhs: S) { $(self.$field /= rhs);+ });
+            impl_fn!(fn rem_assign_element_wise(&mut self, rhs: S) { $(self.$field %= rhs);+ });
         }
 
         impl_scalar_ops!($VectorN<usize> { $($field),+ });
@@ -297,227 +295,6 @@ macro_rules! impl_vector {
         impl_scalar_ops!($VectorN<i32> { $($field),+ });
         impl_scalar_ops!($VectorN<i64> { $($field),+ });
         impl_scalar_ops!($VectorN<f32> { $($field),+ });
-        impl_scalar_ops!($VectorN<f64> { $($field),+ });
-
-        impl_index_operators!($VectorN<S>, $n, S, usize);
-        impl_index_operators!($VectorN<S>, $n, [S], Range<usize>);
-        impl_index_operators!($VectorN<S>, $n, [S], RangeTo<usize>);
-        impl_index_operators!($VectorN<S>, $n, [S], RangeFrom<usize>);
-        impl_index_operators!($VectorN<S>, $n, [S], RangeFull);
-    }
-}
-
-// Utility macro for generating associated functions for the vectors
-// mainly duplication
-#[cfg(feature = "simd")]
-macro_rules! impl_vector_default {
-    ($VectorN:ident { $($field:ident),+ }, $n:expr, $constructor:ident) => {
-        impl<S> $VectorN<S> {
-            /// Construct a new vector, using the provided values.
-            #[inline]
-            pub fn new($($field: S),+) -> $VectorN<S> {
-                $VectorN { $($field: $field),+ }
-            }
-        }
-
-        /// The short constructor.
-        #[inline]
-        pub fn $constructor<S>($($field: S),+) -> $VectorN<S> {
-            $VectorN::new($($field),+)
-        }
-
-        impl<S: NumCast + Copy> $VectorN<S> {
-            /// Component-wise casting to another type.
-            #[inline]
-            pub fn cast<T: NumCast>(&self) -> $VectorN<T> {
-                $VectorN { $($field: NumCast::from(self.$field).unwrap()),+ }
-            }
-        }
-
-        impl<S: BaseFloat> MetricSpace for $VectorN<S> {
-            type Metric = S;
-
-            #[inline]
-            fn distance2(self, other: Self) -> S {
-                (other - self).magnitude2()
-            }
-        }
-
-        impl<S: Copy> Array for $VectorN<S> {
-            type Element = S;
-
-            #[inline]
-            fn len() -> usize {
-                $n
-            }
-
-            #[inline]
-            fn from_value(scalar: S) -> $VectorN<S> {
-                $VectorN { $($field: scalar),+ }
-            }
-
-            #[inline]
-            fn sum(self) -> S where S: Add<Output = S> {
-                fold_array!(add, { $(self.$field),+ })
-            }
-
-            #[inline]
-            fn product(self) -> S where S: Mul<Output = S> {
-                fold_array!(mul, { $(self.$field),+ })
-            }
-        }
-
-        impl<S: BaseNum> Zero for $VectorN<S> {
-            #[inline]
-            fn zero() -> $VectorN<S> {
-                $VectorN::from_value(S::zero())
-            }
-
-            #[inline]
-            fn is_zero(&self) -> bool {
-                *self == $VectorN::zero()
-            }
-        }
-
-        impl<S: BaseNum> iter::Sum for $VectorN<S> {
-            #[inline]
-            fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), Add::add)
-            }
-        }
-
-        impl<'a, S: 'a + BaseNum> iter::Sum<&'a Self> for $VectorN<S> {
-            #[inline]
-            fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold(Self::zero(), Add::add)
-            }
-        }
-
-        impl<S: BaseNum> VectorSpace for $VectorN<S> {
-            type Scalar = S;
-        }
-
-        impl<S: Neg<Output = S>> Neg for $VectorN<S> {
-            type Output = $VectorN<S>;
-
-            #[inline]
-            default fn neg(self) -> $VectorN<S> { $VectorN::new($(-self.$field),+) }
-        }
-
-        impl<S: BaseFloat> ApproxEq for $VectorN<S> {
-            type Epsilon = S::Epsilon;
-
-            #[inline]
-            fn default_epsilon() -> S::Epsilon {
-                S::default_epsilon()
-            }
-
-            #[inline]
-            fn default_max_relative() -> S::Epsilon {
-                S::default_max_relative()
-            }
-
-            #[inline]
-            fn default_max_ulps() -> u32 {
-                S::default_max_ulps()
-            }
-
-            #[inline]
-            fn relative_eq(&self, other: &Self, epsilon: S::Epsilon, max_relative: S::Epsilon) -> bool {
-                $(S::relative_eq(&self.$field, &other.$field, epsilon, max_relative))&&+
-            }
-
-            #[inline]
-            fn ulps_eq(&self, other: &Self, epsilon: S::Epsilon, max_ulps: u32) -> bool {
-                $(S::ulps_eq(&self.$field, &other.$field, epsilon, max_ulps))&&+
-            }
-        }
-
-        impl<S: BaseFloat + Rand> Rand for $VectorN<S> {
-            #[inline]
-            fn rand<R: Rng>(rng: &mut R) -> $VectorN<S> {
-                $VectorN { $($field: rng.gen()),+ }
-            }
-        }
-
-        impl_operator_default!(<S: BaseNum> Add<$VectorN<S> > for $VectorN<S> {
-            fn add(lhs, rhs) -> $VectorN<S> { $VectorN::new($(lhs.$field + rhs.$field),+) }
-        });
-
-        impl_assignment_operator_default!(<S: BaseNum> AddAssign<$VectorN<S> > for $VectorN<S> {
-            fn add_assign(&mut self, other) { $(self.$field += other.$field);+ }
-        });
-
-        impl_operator_default!(<S: BaseNum> Sub<$VectorN<S> > for $VectorN<S> {
-            fn sub(lhs, rhs) -> $VectorN<S> { $VectorN::new($(lhs.$field - rhs.$field),+) }
-        });
-
-        impl_assignment_operator_default!(<S: BaseNum> SubAssign<$VectorN<S> > for $VectorN<S> {
-            fn sub_assign(&mut self, other) { $(self.$field -= other.$field);+ }
-        });
-
-        impl_operator_default!(<S: BaseNum> Mul<S> for $VectorN<S> {
-            fn mul(vector, scalar) -> $VectorN<S> { $VectorN::new($(vector.$field * scalar),+) }
-        });
-
-        impl_assignment_operator_default!(<S: BaseNum> MulAssign<S> for $VectorN<S> {
-            fn mul_assign(&mut self, scalar) { $(self.$field *= scalar);+ }
-        });
-
-        impl_operator_default!(<S: BaseNum> Div<S> for $VectorN<S> {
-            fn div(vector, scalar) -> $VectorN<S> { $VectorN::new($(vector.$field / scalar),+) }
-        });
-
-        impl_assignment_operator_default!(<S: BaseNum> DivAssign<S> for $VectorN<S> {
-            fn div_assign(&mut self, scalar) { $(self.$field /= scalar);+ }
-        });
-
-        impl_operator!(<S: BaseNum> Rem<S> for $VectorN<S> {
-            fn rem(vector, scalar) -> $VectorN<S> { $VectorN::new($(vector.$field % scalar),+) }
-        });
-        impl_assignment_operator!(<S: BaseNum> RemAssign<S> for $VectorN<S> {
-            fn rem_assign(&mut self, scalar) { $(self.$field %= scalar);+ }
-        });
-
-        impl<S: BaseNum> ElementWise for $VectorN<S> {
-            #[inline] default fn add_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field + rhs.$field),+) }
-            #[inline] default fn sub_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field - rhs.$field),+) }
-            #[inline] default fn mul_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field * rhs.$field),+) }
-            #[inline] default fn div_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field / rhs.$field),+) }
-            #[inline] fn rem_element_wise(self, rhs: $VectorN<S>) -> $VectorN<S> { $VectorN::new($(self.$field % rhs.$field),+) }
-
-            #[inline] default fn add_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field += rhs.$field);+ }
-            #[inline] default fn sub_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field -= rhs.$field);+ }
-            #[inline] default fn mul_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field *= rhs.$field);+ }
-            #[inline] default fn div_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field /= rhs.$field);+ }
-            #[inline] fn rem_assign_element_wise(&mut self, rhs: $VectorN<S>) { $(self.$field %= rhs.$field);+ }
-        }
-
-        impl<S: BaseNum> ElementWise<S> for $VectorN<S> {
-            #[inline] default fn add_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field + rhs),+) }
-            #[inline] default fn sub_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field - rhs),+) }
-            #[inline] default fn mul_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field * rhs),+) }
-            #[inline] default fn div_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field / rhs),+) }
-            #[inline] fn rem_element_wise(self, rhs: S) -> $VectorN<S> { $VectorN::new($(self.$field % rhs),+) }
-
-            #[inline] default fn add_assign_element_wise(&mut self, rhs: S) { $(self.$field += rhs);+ }
-            #[inline] default fn sub_assign_element_wise(&mut self, rhs: S) { $(self.$field -= rhs);+ }
-            #[inline] default fn mul_assign_element_wise(&mut self, rhs: S) { $(self.$field *= rhs);+ }
-            #[inline] default fn div_assign_element_wise(&mut self, rhs: S) { $(self.$field /= rhs);+ }
-            #[inline] fn rem_assign_element_wise(&mut self, rhs: S) { $(self.$field %= rhs);+ }
-        }
-
-        impl_scalar_ops!($VectorN<usize> { $($field),+ });
-        impl_scalar_ops!($VectorN<u8> { $($field),+ });
-        impl_scalar_ops!($VectorN<u16> { $($field),+ });
-        impl_scalar_ops_default!($VectorN<u32> { $($field),+ });
-        impl_scalar_ops!($VectorN<u64> { $($field),+ });
-        impl_scalar_ops!($VectorN<isize> { $($field),+ });
-        impl_scalar_ops!($VectorN<i8> { $($field),+ });
-        impl_scalar_ops!($VectorN<i16> { $($field),+ });
-        impl_scalar_ops_default!($VectorN<i32> { $($field),+ });
-        impl_scalar_ops!($VectorN<i64> { $($field),+ });
-        impl_scalar_ops_default!($VectorN<f32> { $($field),+ });
         impl_scalar_ops!($VectorN<f64> { $($field),+ });
 
         impl_index_operators!($VectorN<S>, $n, S, usize);
@@ -542,28 +319,10 @@ macro_rules! impl_scalar_ops {
     };
 }
 
-#[cfg(feature = "simd")]
-macro_rules! impl_scalar_ops_default {
-    ($VectorN:ident<$S:ident> { $($field:ident),+ }) => {
-        impl_operator_default!(Mul<$VectorN<$S>> for $S {
-            fn mul(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar * vector.$field),+) }
-        });
-        impl_operator_default!(Div<$VectorN<$S>> for $S {
-            fn div(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar / vector.$field),+) }
-        });
-        impl_operator_default!(Rem<$VectorN<$S>> for $S {
-            fn rem(scalar, vector) -> $VectorN<$S> { $VectorN::new($(scalar % vector.$field),+) }
-        });
-    };
-}
-
 impl_vector!(Vector1 { x }, 1, vec1);
 impl_vector!(Vector2 { x, y }, 2, vec2);
 impl_vector!(Vector3 { x, y, z }, 3, vec3);
-#[cfg(not(feature = "simd"))]
 impl_vector!(Vector4 { x, y, z, w }, 4, vec4);
-#[cfg(feature = "simd")]
-impl_vector_default!(Vector4 { x, y, z, w }, 4, vec4);
 
 impl_fixed_array_conversions!(Vector1<S> { x: 0 }, 1);
 impl_fixed_array_conversions!(Vector2<S> { x: 0, y: 1 }, 2);


### PR DESCRIPTION
I put all the "default" keyword stuff into a impl_fn! macro. that way, there's way less duplicate code for simd trait implementations

I also feel like there should be a "specialization" or "nightly" feature that's separate from "simd" (that simd enables/depends on). This patch doesn't include that, but makes it easier to implement, since there's only one macro to change

also made a BaseSigned trait so that you can use the trait implementation macros for Neg