### PR TITLE
Implement num_traits::Bounded for Points, Vectors, and Angles

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -22,7 +22,7 @@ use std::ops::*;
 
 use rand::{Rand, Rng};
 use rand::distributions::range::SampleRange;
-use num_traits::cast;
+use num_traits::{cast, Bounded};
 
 use structure::*;
 
@@ -115,6 +115,18 @@ macro_rules! impl_angle {
 
             #[inline]
             fn neg(self) -> $Angle<S> { $Angle(-self.0) }
+        }
+
+        impl<S: Bounded> Bounded for $Angle<S> {
+            #[inline]
+            fn min_value() -> $Angle<S> {
+                $Angle(S::min_value())
+            }
+
+            #[inline]
+            fn max_value() -> $Angle<S> {
+                $Angle(S::max_value())
+            }
         }
 
         impl_operator!(<S: BaseFloat> Add<$Angle<S> > for $Angle<S> {

--- a/src/point.rs
+++ b/src/point.rs
@@ -17,7 +17,7 @@
 //! disinguishes them from vectors, which have a length and direction, but do
 //! not have a fixed position.
 
-use num_traits::NumCast;
+use num_traits::{NumCast, Bounded};
 use std::fmt;
 use std::mem;
 use std::ops::*;
@@ -192,6 +192,18 @@ macro_rules! impl_point {
             #[inline]
             fn ulps_eq(&self, other: &Self, epsilon: S::Epsilon, max_ulps: u32) -> bool {
                 $(S::ulps_eq(&self.$field, &other.$field, epsilon, max_ulps))&&+
+            }
+        }
+
+        impl<S: Bounded> Bounded for $PointN<S> {
+            #[inline]
+            fn min_value() -> $PointN<S> {
+                $PointN { $($field: S::min_value()),+ }
+            }
+
+            #[inline]
+            fn max_value() -> $PointN<S> {
+                $PointN { $($field: S::max_value()),+ }
             }
         }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -25,7 +25,7 @@ use approx::ApproxEq;
 use angle::Rad;
 use num::{BaseNum, BaseFloat};
 
-pub use num_traits::{One, Zero};
+pub use num_traits::{One, Zero, Bounded};
 
 /// An array containing elements of type `Element`
 pub trait Array where

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use rand::{Rand, Rng};
-use num_traits::NumCast;
+use num_traits::{NumCast, Bounded};
 use std::fmt;
 use std::iter;
 use std::mem;
@@ -220,6 +220,18 @@ macro_rules! impl_vector {
             #[inline]
             fn rand<R: Rng>(rng: &mut R) -> $VectorN<S> {
                 $VectorN { $($field: rng.gen()),+ }
+            }
+        }
+
+        impl<S: Bounded> Bounded for $VectorN<S> {
+            #[inline]
+            fn min_value() -> $VectorN<S> {
+                $VectorN { $($field: S::min_value()),+ }
+            }
+
+            #[inline]
+            fn max_value() -> $VectorN<S> {
+                $VectorN { $($field: S::max_value()),+ }
             }
         }
 


### PR DESCRIPTION
Implements [`Bounded`](http://rust-num.github.io/num/num_traits/bounds/trait.Bounded.html) for all Points, Vectors, and Angles where `S` also implements `Bounded`, giving `min_value` and `max_value` functions.

Should `Bounded` be re-exported from the crate root? This PR currently doesn't, but other `num_traits` traits are exported from `cgmath`'s root