### PR TITLE
Modify cast functions to return Option

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1025,8 +1025,14 @@ macro_rules! impl_matrix {
         impl<S: NumCast + Copy> $MatrixN<S> {
             /// Component-wise casting to another type
             #[inline]
-            pub fn cast<T: NumCast>(&self) -> $MatrixN<T> {
-                $MatrixN { $($field: self.$field.cast() ),+ }
+            pub fn cast<T: NumCast>(&self) -> Option<$MatrixN<T>> {
+                $(
+                    let $field = match self.$field.cast() {
+                        Some(field) => field,
+                        None => return None
+                    };
+                )+
+                Some($MatrixN { $($field),+ })
             }
         }
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -127,8 +127,14 @@ macro_rules! impl_point {
         impl<S: NumCast + Copy> $PointN<S> {
             /// Component-wise casting to another type
             #[inline]
-            pub fn cast<T: NumCast>(&self) -> $PointN<T> {
-                $PointN { $($field: NumCast::from(self.$field).unwrap()),+ }
+            pub fn cast<T: NumCast>(&self) -> Option<$PointN<T>> {
+                $(
+                    let $field = match NumCast::from(self.$field) {
+                        Some(field) => field,
+                        None => return None
+                    };
+                )+
+                Some($PointN { $($field),+ })
             }
         }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -234,8 +234,16 @@ impl<S: BaseFloat> MetricSpace for Quaternion<S> {
 
 impl<S: NumCast + Copy> Quaternion<S> {
     /// Component-wise casting to another type.
-    pub fn cast<T: BaseFloat>(&self) -> Quaternion<T> {
-        Quaternion::from_sv(NumCast::from(self.s).unwrap(), self.v.cast())
+    pub fn cast<T: BaseFloat>(&self) -> Option<Quaternion<T>> {
+        let s = match NumCast::from(self.s) {
+            Some(s) => s,
+            None => return None
+        };
+        let v = match self.v.cast() {
+            Some(v) => v,
+            None => return None
+        };
+        Some(Quaternion::from_sv(s, v))
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -347,8 +347,14 @@ macro_rules! impl_vector_default {
         impl<S: NumCast + Copy> $VectorN<S> {
             /// Component-wise casting to another type.
             #[inline]
-            pub fn cast<T: NumCast>(&self) -> $VectorN<T> {
-                $VectorN { $($field: NumCast::from(self.$field).unwrap()),+ }
+            pub fn cast<T: NumCast>(&self) -> Option<$VectorN<T>> {
+                $(
+                    let $field = match NumCast::from(self.$field) {
+                        Some(field) => field,
+                        None => return None
+                    };
+                )+
+                Some($VectorN { $($field),+ })
             }
         }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -112,8 +112,14 @@ macro_rules! impl_vector {
         impl<S: NumCast + Copy> $VectorN<S> {
             /// Component-wise casting to another type.
             #[inline]
-            pub fn cast<T: NumCast>(&self) -> $VectorN<T> {
-                $VectorN { $($field: NumCast::from(self.$field).unwrap()),+ }
+            pub fn cast<T: NumCast>(&self) -> Option<$VectorN<T>> {
+                $(
+                    let $field = match NumCast::from(self.$field) {
+                        Some(field) => field,
+                        None => return None
+                    };
+                )+
+                Some($VectorN { $($field),+ })
             }
         }
 

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -741,12 +741,12 @@ pub mod matrix4 {
 
     #[test]
     fn test_cast() {
-        assert_ulps_eq!(Matrix2::new(0.2f64, 1.5, 4.7, 2.3).cast(), Matrix2::new(0.2f32, 1.5, 4.7, 2.3));
+        assert_ulps_eq!(Matrix2::new(0.2f64, 1.5, 4.7, 2.3).cast().unwrap(), Matrix2::new(0.2f32, 1.5, 4.7, 2.3));
         assert_ulps_eq!(Matrix3::new(
             0.2f64, 1.5, 4.7,
             2.3,    5.7, 2.1,
             4.6,    5.2, 6.6,
-        ).cast(), Matrix3::new(
+        ).cast().unwrap(), Matrix3::new(
             0.2f32, 1.5, 4.7,
             2.3,    5.7, 2.1,
             4.6,    5.2, 6.6,
@@ -757,7 +757,7 @@ pub mod matrix4 {
             2.3,    5.7, 2.1, 1.1,
             4.6,    5.2, 6.6, 0.2,
             3.2,    1.8, 0.4, 2.9,
-        ).cast(), Matrix4::new(
+        ).cast().unwrap(), Matrix4::new(
             0.2f32, 1.5, 4.7, 2.5,
             2.3,    5.7, 2.1, 1.1,
             4.6,    5.2, 6.6, 0.2,

--- a/tests/point.rs
+++ b/tests/point.rs
@@ -77,7 +77,7 @@ fn test_rem() {
 
 #[test]
 fn test_cast() {
-    assert_ulps_eq!(Point1::new(0.9f64).cast(), Point1::new(0.9f32));
-    assert_ulps_eq!(Point2::new(0.9f64, 1.5).cast(), Point2::new(0.9f32, 1.5));
-    assert_ulps_eq!(Point3::new(1.0f64, 2.4, -3.13).cast(), Point3::new(1.0f32, 2.4, -3.13));
+    assert_ulps_eq!(Point1::new(0.9f64).cast().unwrap(), Point1::new(0.9f32));
+    assert_ulps_eq!(Point2::new(0.9f64, 1.5).cast().unwrap(), Point2::new(0.9f32, 1.5));
+    assert_ulps_eq!(Point3::new(1.0f64, 2.4, -3.13).cast().unwrap(), Point3::new(1.0f32, 2.4, -3.13));
 }

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -337,7 +337,7 @@ mod cast {
 
     #[test]
     fn test_cast() {
-        assert_ulps_eq!(Quaternion::new(0.9f64, 1.5, 2.4, 7.6).cast(),
+        assert_ulps_eq!(Quaternion::new(0.9f64, 1.5, 2.4, 7.6).cast().unwrap(),
                         Quaternion::new(0.9f32, 1.5, 2.4, 7.6));
     }
 }

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -250,7 +250,7 @@ fn test_normalize() {
 
 #[test]
 fn test_cast() {
-    assert_ulps_eq!(Vector2::new(0.9f64, 1.5).cast(), Vector2::new(0.9f32, 1.5));
-    assert_ulps_eq!(Vector3::new(1.0f64, 2.4, -3.13).cast(), Vector3::new(1.0f32, 2.4, -3.13));
-    assert_ulps_eq!(Vector4::new(13.5f64, -4.6, -8.3, 2.41).cast(), Vector4::new(13.5f32, -4.6, -8.3, 2.41));
+    assert_ulps_eq!(Vector2::new(0.9f64, 1.5).cast().unwrap(), Vector2::new(0.9f32, 1.5));
+    assert_ulps_eq!(Vector3::new(1.0f64, 2.4, -3.13).cast().unwrap(), Vector3::new(1.0f32, 2.4, -3.13));
+    assert_ulps_eq!(Vector4::new(13.5f64, -4.6, -8.3, 2.41).cast().unwrap(), Vector4::new(13.5f32, -4.6, -8.3, 2.41));
 }

--- a/tests/vector4f32.rs
+++ b/tests/vector4f32.rs
@@ -171,5 +171,5 @@ fn test_normalize() {
 
 #[test]
 fn test_cast() {
-    assert_ulps_eq!(Vector4::new(13.5f32, -4.6, -8.3, 2.41).cast(), Vector4::new(13.5f32, -4.6, -8.3, 2.41));
+    assert_ulps_eq!(Vector4::new(13.5f32, -4.6, -8.3, 2.41).cast().unwrap(), Vector4::new(13.5f32, -4.6, -8.3, 2.41));
 }


### PR DESCRIPTION
Right now, the `cast()` functions simply panic when a cast fails, crashing the entire program unhandleably (ignoring panic hooks). This PR makes said functions return `Option<_>`, so that a program may catch and handle failed casts. Unfortunately this is a breaking change, but programs should be able to handle a failed cast which can reasonably happen even within properly-implemented code.