### PR TITLE
Adding inverse transformation of a vector to the Transform trait.

### DIFF
--- a/src/transform.rs
+++ b/src/transform.rs
@@ -37,6 +37,11 @@ pub trait Transform<P: EuclideanSpace>: Sized {
     /// Transform a vector using this transform.
     fn transform_vector(&self, vec: P::Diff) -> P::Diff;
 
+    /// Inverse transform a vector using this transform
+    fn inverse_transform_vector(&self, vec: P::Diff) -> Option<P::Diff> {
+        self.inverse_transform().and_then(|inverse| Some(inverse.transform_vector(vec)))
+    }
+
     /// Transform a point using this transform.
     fn transform_point(&self, point: P) -> P;
 
@@ -91,6 +96,15 @@ impl<P: EuclideanSpace, R: Rotation<P>> Transform<P> for Decomposed<P::Diff, R>
     #[inline]
     fn transform_vector(&self, vec: P::Diff) -> P::Diff {
         self.rot.rotate_vector(vec * self.scale)
+    }
+
+    #[inline]
+    fn inverse_transform_vector(&self, vec: P::Diff) -> Option<P::Diff> {
+        if ulps_eq!(self.scale, &P::Scalar::zero()) {
+            None
+        } else {
+            Some(self.rot.invert().rotate_vector(vec / self.scale))
+        }
     }
 
     #[inline]

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -36,6 +36,18 @@ fn test_invert() {
 }
 
 #[test]
+fn test_inverse_vector() {
+    let v = Vector3::new(1.0f64, 2.0, 3.0);
+    let t = Decomposed {
+        scale: 1.5f64,
+        rot: Quaternion::new(0.5f64, 0.5, 0.5, 0.5),
+        disp: Vector3::new(6.0f64, -7.0, 8.0),
+    };
+    let vt = t.inverse_transform_vector(v).expect("Expected successful inversion");
+    assert_ulps_eq!(v, t.transform_vector(vt));
+}
+
+#[test]
 fn test_look_at() {
     let eye = Point3::new(0.0f64, 0.0, -5.0);
     let center = Point3::new(0.0f64, 0.0, 0.0);


### PR DESCRIPTION
This is heavily used in collision detection. It's much cheaper to do the inverse transform of a ray/support function direction vector/etc, than to transform all the vertices of a primitive/complex shape.

We've found ourselves writing: `transform.inverse_transform().and_then(|inverse| Some(inverse.transform_vector(some_vec)))` over and over, so we felt there was a solid use case for having this in cgmath. It is also something that specific implementations of the Transform trait can do a much better version of than doing the full inverse of the transform, since vector space has no concept of translation.