### PR TITLE
Use transmute_copy for into impl

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -142,7 +142,7 @@ macro_rules! fold_array {
 /// Generate array conversion implementations for a compound array type
 macro_rules! impl_fixed_array_conversions {
     ($ArrayN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {
-        impl<$S> Into<[$S; $n]> for $ArrayN<$S> {
+        impl<$S: Copy> Into<[$S; $n]> for $ArrayN<$S> {
             #[inline]
             fn into(self) -> [$S; $n] {
                 unsafe { mem::transmute_copy(&self) }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -145,7 +145,7 @@ macro_rules! impl_fixed_array_conversions {
         impl<$S> Into<[$S; $n]> for $ArrayN<$S> {
             #[inline]
             fn into(self) -> [$S; $n] {
-                match self { $ArrayN { $($field),+ } => [$($field),+] }
+                unsafe { mem::transmute_copy(&self) }
             }
         }
 
@@ -163,11 +163,11 @@ macro_rules! impl_fixed_array_conversions {
             }
         }
 
-        impl<$S: Clone> From<[$S; $n]> for $ArrayN<$S> {
+        impl<$S> From<[$S; $n]> for $ArrayN<$S> {
             #[inline]
             fn from(v: [$S; $n]) -> $ArrayN<$S> {
                 // We need to use a clone here because we can't pattern match on arrays yet
-                $ArrayN { $($field: v[$index].clone()),+ }
+                unsafe { mem::transmute_copy(&v) }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/brendanzab/cgmath/issues/436

So while this isn't a perfect no-op like I hoped for it's still a slight improvement over what was present.  A transmute without _copy wasn't possible because even though it is possible to prove Vector3\<S\> is the same size as [S; 3] rustc just isn't that smart yet.  So this is the next best thing.