### PR TITLE
Bumped rand to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ swizzle = []
 approx = "0.2"
 mint = { version = "0.5", optional = true }
 num-traits = "0.2"
-rand = "0.4"
+rand = "0.5"
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 simd = { version = "0.2", optional = true }
 

--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -19,7 +19,7 @@ macro_rules! bench_binop {
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 13;
 
-            let mut rng = IsaacRng::new_unseeded();
+            let mut rng = IsaacRng::from_entropy();
 
             let elems1: Vec<$t1> = (0..LEN).map(|_| rng.gen::<$t1>()).collect();
             let elems2: Vec<$t2> = (0..LEN).map(|_| rng.gen::<$t2>()).collect();
@@ -42,7 +42,7 @@ macro_rules! bench_unop {
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 13;
 
-            let mut rng = IsaacRng::new_unseeded();
+            let mut rng = IsaacRng::from_entropy();
 
             let mut elems: Vec<$t> = (0..LEN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
@@ -64,7 +64,7 @@ macro_rules! bench_construction {
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 13;
 
-            let mut rng = IsaacRng::new_unseeded();
+            let mut rng = IsaacRng::from_entropy();
 
             $(let $args: Vec<$types> = (0..LEN).map(|_| rng.gen::<$types>()).collect();)*
             let mut i = 0;

--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -14,12 +14,13 @@
 // limitations under the License.
 
 #![feature(test)]
+#![allow(unused_macros)]
 
 extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng, FromEntropy};
 use test::Bencher;
 use cgmath::*;
 
@@ -30,7 +31,7 @@ mod macros;
 fn bench_from_axis_angle<T: Rotation3<f32>>(bh: &mut Bencher) {
     const LEN: usize = 1 << 13;
 
-    let mut rng = IsaacRng::new_unseeded();
+    let mut rng = IsaacRng::from_entropy();
 
     let axis: Vec<_> = (0..LEN).map(|_| rng.gen::<Vector3<f32>>()).collect();
     let angle: Vec<_> = (0..LEN).map(|_| rng.gen::<Rad<f32>>()).collect();

--- a/benches/mat.rs
+++ b/benches/mat.rs
@@ -14,12 +14,13 @@
 // limitations under the License.
 
 #![feature(test)]
+#![allow(unused_macros)]
 
 extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng, FromEntropy};
 use std::ops::*;
 use test::Bencher;
 

--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -19,7 +19,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng, FromEntropy};
 use std::ops::*;
 use test::Bencher;
 

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -14,12 +14,13 @@
 // limitations under the License.
 
 #![feature(test)]
+#![allow(unused_macros)]
 
 extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{IsaacRng, Rng};
+use rand::{IsaacRng, Rng, FromEntropy};
 use std::ops::*;
 use test::Bencher;
 

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -20,8 +20,9 @@ use std::f64;
 use std::iter;
 use std::ops::*;
 
-use rand::{Rand, Rng};
-use rand::distributions::range::SampleRange;
+use rand::Rng;
+use rand::distributions::{Distribution, Standard};
+use rand::distributions::uniform::SampleUniform;
 use num_traits::{cast, Bounded};
 
 use structure::*;
@@ -207,10 +208,12 @@ macro_rules! impl_angle {
                 S::ulps_eq(&self.0, &other.0, epsilon, max_ulps)
             }
         }
-
-        impl<S: BaseFloat + SampleRange> Rand for $Angle<S> {
+    
+        impl<S> Distribution<$Angle<S>> for Standard 
+            where Standard: Distribution<S>,
+                S: BaseFloat + SampleUniform {
             #[inline]
-            fn rand<R: Rng>(rng: &mut R) -> $Angle<S> {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $Angle<S> {
                 $Angle(rng.gen_range(cast(-$hi).unwrap(), cast($hi).unwrap()))
             }
         }

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{Rand, Rng};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 use num_traits::cast;
 
 use structure::*;
@@ -185,9 +186,10 @@ impl<A: Angle> approx::UlpsEq for Euler<A> {
     }
 }
 
-impl<A: Angle + Rand> Rand for Euler<A> {
-    #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> Euler<A> {
+impl<A> Distribution<Euler<A>> for Standard
+    where Standard: Distribution<A>,
+        A: Angle {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Euler<A> {
         Euler {
             x: rng.gen(),
             y: rng.gen(),

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{Rand, Rng};
+use rand::distributions::{Standard, Distribution};
+use rand::Rng;
 use num_traits::{cast, NumCast};
 use std::fmt;
 use std::iter;
@@ -1529,19 +1530,24 @@ impl<S: fmt::Debug> fmt::Debug for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat + Rand> Rand for Matrix2<S> {
+impl<S> Distribution<Matrix2<S>> for Standard
+    where 
+        Standard: Distribution<Vector2<S>>,
+        S: BaseFloat {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> Matrix2<S> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix2<S> {
         Matrix2 {
-            x: rng.gen(),
-            y: rng.gen(),
+            x: self.sample(rng),
+            y: self.sample(rng),
         }
     }
 }
 
-impl<S: BaseFloat + Rand> Rand for Matrix3<S> {
+impl<S> Distribution<Matrix3<S>> for Standard
+    where Standard: Distribution<Vector3<S>>,
+        S: BaseFloat {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> Matrix3<S> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix3<S> {
         Matrix3 {
             x: rng.gen(),
             y: rng.gen(),
@@ -1550,9 +1556,11 @@ impl<S: BaseFloat + Rand> Rand for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat + Rand> Rand for Matrix4<S> {
+impl<S> Distribution<Matrix4<S>> for Standard
+    where Standard: Distribution<Vector4<S>>,
+        S: BaseFloat {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> Matrix4<S> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix4<S> {
         Matrix4 {
             x: rng.gen(),
             y: rng.gen(),

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -17,7 +17,8 @@ use std::iter;
 use std::mem;
 use std::ops::*;
 
-use rand::{Rand, Rng};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 use num_traits::{cast, NumCast};
 
 use structure::*;
@@ -864,9 +865,12 @@ index_operators!(S, [S], RangeTo<usize>);
 index_operators!(S, [S], RangeFrom<usize>);
 index_operators!(S, [S], RangeFull);
 
-impl<S: BaseFloat + Rand> Rand for Quaternion<S> {
+impl<S> Distribution<Quaternion<S>> for Standard 
+    where Standard: Distribution<S>,
+        Standard: Distribution<Vector3<S>>,
+        S: BaseFloat {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> Quaternion<S> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Quaternion<S> {
         Quaternion::from_sv(rng.gen(), rng.gen())
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -502,9 +502,11 @@ macro_rules! impl_vector_default {
             }
         }
 
-        impl<S: BaseFloat + Rand> Rand for $VectorN<S> {
+        impl<S> Distribution<$VectorN<S>> for Standard 
+            where S: BaseFloat,
+                Standard: Distribution<S>  {
             #[inline]
-            fn rand<R: Rng>(rng: &mut R) -> $VectorN<S> {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $VectorN<S> {
                 $VectorN { $($field: rng.gen()),+ }
             }
         }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::{Rand, Rng};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 use num_traits::{Bounded, NumCast};
 use std::fmt;
 use std::iter;
@@ -244,9 +245,11 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<S: BaseFloat + Rand> Rand for $VectorN<S> {
+        impl<S> Distribution<$VectorN<S>> for Standard
+            where Standard: Distribution<S>,
+                S: BaseFloat {
             #[inline]
-            fn rand<R: Rng>(rng: &mut R) -> $VectorN<S> {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $VectorN<S> {
                 $VectorN { $($field: rng.gen()),+ }
             }
         }


### PR DESCRIPTION
Rand 0.5 has a couple of warnings and breaking changes:

`Rand` is deprecated and replaced with a Distribution construction:

```rust
impl<S: BaseFloat + SampleRange> Rand for $Angle<S> {
    #[inline]
    fn rand<R: Rng>(rng: &mut R) -> $Angle<S> {
        $Angle(rng.gen_range(cast(-$hi).unwrap(), cast($hi).unwrap()))
    }
}
```
becomes
```rust
impl<S> Distribution<$Angle<S>> for Standard 
	where Standard: Distribution<S>,
		S: BaseFloat + SampleUniform {
	#[inline]
	fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $Angle<S> {
		$Angle(rng.gen_range(cast(-$hi).unwrap(), cast($hi).unwrap()))
	}
}
```

`IsaacRng::new_unseeded` is deprecated, and rand recommends using [FromEntropy](https://docs.rs/rand/0.5.0/rand/trait.FromEntropy.html). Other options are (from rand's docs):
- Deterministic creation using SeedableRng::from_seed with a fixed seed
- Seeding from thread_rng: SeedableRng::from_rng(thread_rng())?; this will usually be faster and should also be secure, but requires trusting one extra component.

I also added some `#![allow(unused_macros)]`'s to the benchmarks to stop RLS from complaining.
