### PR TITLE
Fix links to OpenGL API in docs

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -24,8 +24,9 @@ use num::BaseFloat;
 
 /// Create a perspective projection matrix.
 ///
-/// This is the equivalent to the [gluPerspective]
-/// (http://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml) function.
+/// This is the equivalent to the [`gluPerspective`] function.
+///
+/// [`gluPerspective`]: https://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml
 pub fn perspective<S: BaseFloat, A: Into<Rad<S>>>(
     fovy: A,
     aspect: S,
@@ -42,8 +43,9 @@ pub fn perspective<S: BaseFloat, A: Into<Rad<S>>>(
 
 /// Create a perspective matrix from a view frustum.
 ///
-/// This is the equivalent of the now deprecated [glFrustum]
-/// (http://www.opengl.org/sdk/docs/man2/xhtml/glFrustum.xml) function.
+/// This is the equivalent of the now deprecated [`glFrustum`] function.
+///
+/// [`glFrustum`]: http://www.opengl.org/sdk/docs/man2/xhtml/glFrustum.xml
 pub fn frustum<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S) -> Matrix4<S> {
     Perspective {
         left: left,
@@ -57,8 +59,9 @@ pub fn frustum<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far:
 
 /// Create an orthographic projection matrix.
 ///
-/// This is the equivalent of the now deprecated [glOrtho]
-/// (http://www.opengl.org/sdk/docs/man2/xhtml/glOrtho.xml) function.
+/// This is the equivalent of the now deprecated [`glOrtho`] function.
+///
+/// [`glOrtho`]: http://www.opengl.org/sdk/docs/man2/xhtml/glOrtho.xml
 pub fn ortho<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S) -> Matrix4<S> {
     Ortho {
         left: left,


### PR DESCRIPTION
Those links were broken before, since the [] and () part were split
into two different lines. This also caused warnings on nightly, which
are now fixed.